### PR TITLE
Remove character limit from short synopsis field

### DIFF
--- a/app/views/projects/_form.html.erb
+++ b/app/views/projects/_form.html.erb
@@ -100,10 +100,9 @@
         <%= form.label :short_synopsis, "Sinopsis Corta", class: "block text-sm font-medium text-gray-700" %>
         <%= form.text_area :short_synopsis,
                            rows: 6,
-                           maxlength: 1500,
                            class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm",
                            placeholder: "Descripción breve de la historia (2-3 párrafos)..." %>
-        <p class="mt-1 text-xs text-gray-500">Máximo 1500 caracteres</p>
+        <p class="mt-1 text-xs text-gray-500">Sin límite de caracteres</p>
       </div>
 
       <!-- Sinopsis Larga -->


### PR DESCRIPTION
## Summary

This PR removes the 1500 character limit from the short synopsis field in the project form, allowing users to write synopses of any length.

## What Changed

- Removed `maxlength: 1500` attribute from the short synopsis textarea in `app/views/projects/_form.html.erb`
- Updated help text from "Máximo 1500 caracteres" to "Sin límite de caracteres"

## Why

Users need the flexibility to write more detailed short synopses without being constrained by an arbitrary character limit. The database already supports this (using `text` type), so this change simply removes the frontend restriction.

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)